### PR TITLE
Use memo instead of status

### DIFF
--- a/oaatoperator/handlers.py
+++ b/oaatoperator/handlers.py
@@ -124,6 +124,7 @@ def pod_phasechange(**kwargs: Unpack[CallbackArgs]):
     Triggered by change in the pod's "phase" status field, or every
     1/2 hour just in case
     """
+    memo = kwargs['memo']
     kwargs['logger'].debug(
         f'[{my_name()}] reason: {kwargs.get("reason", "timer?")}')
     try:
@@ -136,6 +137,7 @@ def pod_phasechange(**kwargs: Unpack[CallbackArgs]):
     try:
         pod.update_phase()
     except ProcessingComplete as exc:
+        pod.get_parent().set_status('handler_status', memo)
         return pod.handle_processing_complete(exc)
 
     return {'message': f'[{my_name()}] should never happen'}
@@ -159,6 +161,7 @@ def pod_succeeded(**kwargs: Unpack[CallbackArgs]):
     Record last_success for failed pod. Triggered by change in the
     pod's "phase" status field, or every 1/2 hour just in case
     """
+    memo = kwargs['memo']
     kwargs['logger'].debug(
         f'[{my_name()}] reason: {kwargs.get("reason", "timer?")}')
     try:
@@ -169,6 +172,7 @@ def pod_succeeded(**kwargs: Unpack[CallbackArgs]):
     try:
         pod.update_success_status()
     except ProcessingComplete as exc:
+        pod.get_parent().set_status('handler_status', memo)
         return pod.handle_processing_complete(exc)
 
     return {'message': f'[{my_name()}] should never happen'}
@@ -192,6 +196,7 @@ def pod_failed(**kwargs: Unpack[CallbackArgs]):
     Record last_failure for failed pod. Triggered by change in the
     pod's "phase" status field, or every 1/2 hour just in case
     """
+    memo = kwargs['memo']
     kwargs['logger'].debug(
         f'[{my_name()}] reason: {kwargs.get("reason", "timer?")}')
     try:
@@ -203,6 +208,7 @@ def pod_failed(**kwargs: Unpack[CallbackArgs]):
     try:
         pod.update_failure_status()
     except ProcessingComplete as exc:
+        pod.get_parent().set_status('handler_status', memo)
         return pod.handle_processing_complete(exc)
 
     return {'message': f'[{my_name()}] should never happen'}
@@ -256,6 +262,7 @@ def oaat_resume(**kwargs: Unpack[CallbackArgs]):
         memo.pod = running_pod_info.get('name', 'unknown')
 
     oaatgroup.info(f'[{my_name()}] {oaatgroup.name}')
+    oaatgroup.set_status('handler_status', memo)
     return {'message': f'Successfully resumed {oaatgroup.name}'}
 
 
@@ -270,11 +277,12 @@ def oaat_action(**kwargs: Unpack[CallbackArgs]):
     """
     oaat_action (oaatgroup)
 
-    Handle create/update/resume events for OaatGroup object:
+    Handle create/update events for OaatGroup object:
         * validate oaatType
         * ensure "items" exist
         * annotate self with "operator-status=active" to enable timer
     """
+    memo = kwargs['memo']
     kwargs['logger'].debug(
         f'[{my_name()}] reason: {kwargs.get("reason", "timer?")}')
     try:
@@ -290,6 +298,7 @@ def oaat_action(**kwargs: Unpack[CallbackArgs]):
             count_annotation='oaatgroup-items')
         raise ProcessingComplete(message='validated')
     except ProcessingComplete as exc:
+        oaatgroup.set_status('handler_status', memo)
         return oaatgroup.handle_processing_complete(exc)
 
 

--- a/oaatoperator/oaatitem.py
+++ b/oaatoperator/oaatitem.py
@@ -106,7 +106,8 @@ class OaatItems:
     def __init__(self, group: OaatGroup, obj: dict[str, Any]) -> None:
         if not isinstance(obj, dict):
             print(f'obj: {obj}')
-            raise TypeError(f'obj should be dict, not {type(obj)}={obj}')
+            raise kopf.PermanentError(
+                f'obj should be dict, not {type(obj)}={obj}')
         self.obj = obj
         self.group = group
 

--- a/oaatoperator/overseer.py
+++ b/oaatoperator/overseer.py
@@ -4,6 +4,7 @@ overseer.py
 Overseer base class for Kopf object processing.
 """
 from typing_extensions import Unpack
+import kopf
 import pykube
 from typing import Any, Optional, Type
 from oaatoperator.common import ProcessingComplete
@@ -27,6 +28,7 @@ class Overseer:
         self.logger: logging.Logger = kwargs.get('logger')
         self.body = kwargs.get('body')
         self.meta = kwargs.get('meta')
+        self.memo = kwargs.get('memo')
         self.spec = kwargs.get('spec', {})
         self.namespace = kwargs.get('namespace')
         self.my_pykube_objtype: Optional[Type[pykube.objects.APIObject]] = None
@@ -38,8 +40,8 @@ class Overseer:
         ]
 
         if None in required_kwargs:
-            raise ValueError('Overseer must be called with full kopf '
-                             f'kwargs ({required_kwargs}')
+            raise kopf.PermanentError('Overseer must be called with full kopf '
+                                      f'kwargs ({required_kwargs}')
 
     def error(self, *args) -> None:
         """Log an error."""

--- a/oaatoperator/py_types.py
+++ b/oaatoperator/py_types.py
@@ -4,6 +4,7 @@ py_types.py
 Types used for type validation.
 """
 from typing import Any, TypedDict, Optional, Union
+import kopf
 from kopf._cogs.structs import bodies, references, patches, diffs
 import datetime
 import logging
@@ -31,5 +32,5 @@ class CallbackArgs(TypedDict):
     old: Optional[Union[bodies.BodyEssence, Any]]
     new: Optional[Union[bodies.BodyEssence, Any]]
     logger: logging.Logger
-    memo: Any
+    memo: kopf.Memo
     param: Any

--- a/oaatoperator/utility.py
+++ b/oaatoperator/utility.py
@@ -103,7 +103,10 @@ def parse_duration(duration: str) -> Optional[datetime.timedelta]:
                 units['days'] = units.setdefault('days', 0) + val
             if unit[0] == 'w':
                 units['weeks'] = units.setdefault('weeks', 0) + val
-    return datetime.timedelta(**units)
+    if units:
+        return datetime.timedelta(**units)
+    else:
+        return None
 
 
 def date_from_isostr(datestr: str) -> datetime.datetime:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,8 +1,8 @@
 -r common.txt
 coverage==6.5.0
-flake8==5.0.4
-pycodestyle==2.9.1
-pyflakes==2.5.0
+flake8==6.0.0
+pycodestyle==2.10.0
+pyflakes==3.0.0
 pytest==7.2.0
 pytest-cov==4.0.0
 pytest-mock==3.10.0

--- a/tests/operator_overseer.py
+++ b/tests/operator_overseer.py
@@ -9,10 +9,10 @@ from oaatoperator.overseer import Overseer
 
 @kopf.on.create('pods')  # type: ignore
 def create_action(**kwargs):
-    # [1] Overseer should raise ValueError if kwargs are not passed
+    # [1] Overseer should raise kopf.PermanentError if kwargs are not passed
     try:
         Overseer()  # type: ignore
-    except ValueError as exc:
+    except kopf.PermanentError as exc:
         assert re.search('Overseer must be called with full kopf kwargs',
                          str(exc)), exc
         kwargs['logger'].debug('[1] successful')

--- a/tests/run-e2e-test.sh
+++ b/tests/run-e2e-test.sh
@@ -42,7 +42,7 @@ for dir in *; do
          ${dir}/update-steps.sh
          echo "**** running ${dir} test ****"
          sleep 60
-         (cd ..; kubectl kuttl test --timeout 240 --test ${dir})
+         (cd ..; kubectl kuttl test --skip-delete --timeout 240 --test ${dir})
          echo "**** cleaning up ${dir} test ****"
          k3d cluster delete ${dir}x
          ${dir}/update-steps.sh --cleanup

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -259,13 +259,11 @@ class TestHandlerOaatTimer(unittest.TestCase):
         self.ogi.get_status = MagicMock(side_effect=[5])
         self.ogi.validate_items = MagicMock(side_effect=[None])
         self.ogi.verify_running = MagicMock(side_effect=[None])
-        self.ogi.verify_state = MagicMock(side_effect=[None])
-        self.ogi.delete_rogue_pods = MagicMock(side_effect=[None])
-        self.ogi.is_pod_expected = MagicMock(side_effect=[True])
-        self.ogi.verify_expected_pod_is_running = MagicMock(side_effect=[
-            ProcessingComplete(
-                message='pod xxx exists and is in state Running')
-        ])
+        self.ogi.verify_running_pod = MagicMock(side_effect=[None])
+        self.ogi.identify_running_pod = MagicMock(side_effect=[None])
+        self.ogi.resume_running_pod = MagicMock(side_effect=[None])
+        self.ogi.delete_non_survivor_pods = MagicMock(side_effect=[None])
+        self.ogi.select_survivor = MagicMock(side_effect=[None])
         self.ogi.find_job_to_run = MagicMock(spec=OaatItem)
         item = self.ogi.find_job_to_run.return_value
         item.name = 'item'  # name is special
@@ -297,7 +295,7 @@ class TestHandlerOaatTimer(unittest.TestCase):
         result = self.ogi.handle_processing_complete.call_args[0][0].ret
         self.assertEqual(self.ogi.validate_items.call_count, 1)
         self.assertEqual(self.ogi.verify_running.call_count, 1)
-        self.assertEqual(self.ogi.find_job_to_run.call_count, 1)
+        self.assertEqual(self.ogi.find_job_to_run.call_count, 0)
         self.assertEqual(
             self.ogi.find_job_to_run.return_value.run.call_count, 0)
         self.assertEqual(result.get('message'),

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -81,6 +81,7 @@ class TestHandlerOaatAction(unittest.TestCase):
         ogi = og.return_value
         ogi.validate_items = Mock(side_effect=[None])
         ogi.handle_processing_complete = Mock(return_value={})
+        ogi.set_status = Mock(return_value=None)
         ogi.info = print
         ogi.name = 'name'
         oaatoperator.handlers.oaat_action(**kw)  # type: ignore
@@ -103,6 +104,7 @@ class TestHandlerOaatAction(unittest.TestCase):
         ogi.validate_items = Mock(
             side_effect=[ProcessingComplete(message='ogmessage')])
         ogi.handle_processing_complete = Mock(return_value={})
+        ogi.set_status = Mock(return_value=None)
         ogi.info = print
         ogi.name = 'name'
         oaatoperator.handlers.oaat_action(**kw)  # type: ignore

--- a/tests/test_oaatgroup.py
+++ b/tests/test_oaatgroup.py
@@ -540,7 +540,7 @@ class OaatGroupTests(unittest.TestCase):
            obj=TestData.kot_mock)
     def test_no_kopf(self, _):
         with KubeObject(KubeOaatGroup, TestData.kog_attrs):
-            og = OaatGroup(kube_object_name='test-kog', logger=MagicMock())
+            og = OaatGroup(kube_object_name='test-kog', memo=MagicMock(), logger=MagicMock())
             with self.assertRaisesRegex(
                     kopf.PermanentError,
                     'attempt to retrieve find_job_to_run outside of kopf'):
@@ -593,7 +593,7 @@ class OaatGroupTests(unittest.TestCase):
            obj=TestData.kot_mock)
     def test_create_with_kubeobj(self, _):
         with KubeObject(KubeOaatGroup, TestData.kog_attrs):
-            og = OaatGroup(kube_object_name='test-kog', logger=MagicMock())
+            og = OaatGroup(kube_object_name='test-kog', memo=MagicMock(), logger=MagicMock())
             self.assertIsInstance(og.kube_object, KubeOaatGroup)
             self.assertEqual(og.kopf_object, None)
             self.assertEqual(og.kube_object.name,
@@ -608,7 +608,17 @@ class OaatGroupTests(unittest.TestCase):
             with self.assertRaisesRegex(
                     kopf.PermanentError,
                     'must supply logger= parameter .*kube_object_name'):
-                OaatGroup(kube_object_name='test-kog')
+                OaatGroup(kube_object_name='test-kog', memo=MagicMock())
+
+    @patch('oaatoperator.oaatgroup.OaatType',
+           autospec=True,
+           obj=TestData.kot_mock)
+    def test_create_with_kubeobj_no_memo(self, _):
+        with KubeObject(KubeOaatGroup, TestData.kog_attrs):
+            with self.assertRaisesRegex(
+                    kopf.PermanentError,
+                    'must supply memo= parameter .*kube_object_name'):
+                OaatGroup(kube_object_name='test-kog', logger=MagicMock())
 
     @patch('oaatoperator.oaatgroup.OaatType',
            autospec=True,

--- a/tests/test_oaatgroup.py
+++ b/tests/test_oaatgroup.py
@@ -3,6 +3,7 @@ import os
 from copy import deepcopy
 import datetime
 import pykube
+import kopf
 from typing import cast
 
 import unittest
@@ -19,7 +20,7 @@ from tests.testdata import TestData  # noqa: E402
 
 from oaatoperator.oaatgroup import OaatGroup, OaatGroupOverseer  # noqa: E402
 from oaatoperator.py_types import CallbackArgs  # noqa: E402
-from oaatoperator.common import (InternalError, KubeOaatGroup,  # noqa: E402
+from oaatoperator.common import (KubeOaatGroup,  # noqa: E402
                                  ProcessingComplete)
 import oaatoperator.utility  # noqa: E402
 
@@ -53,14 +54,14 @@ class BasicTests(unittest.TestCase):
         self.assertEqual(kobj.name, TestData.kog_attrs['metadata']['name'])
 
     def test_invalid_object(self):
-        with self.assertRaises(ValueError) as exc:
+        with self.assertRaises(kopf.PermanentError) as exc:
             OaatGroup(kopf_object={})  # type: ignore
             self.assertRegex(
-                    str(exc.exception),
-                    'Overseer must be called with full kopf kwargs.*')
+                str(exc.exception),
+                'Overseer must be called with full kopf kwargs.*')
 
     def test_invalid_none(self):
-        with self.assertRaises(InternalError):
+        with self.assertRaises(kopf.PermanentError):
             OaatGroup(kopf_object=None)  # type: ignore
 
     def test_podspec_emptyspec(self):
@@ -71,6 +72,22 @@ class BasicTests(unittest.TestCase):
                     TestData.setup_kwargs(TestData.kog_emptyspec_attrs)))
             self.assertEqual(exc.exception.ret['error'],
                              'cannot find OaatType None')
+
+    @patch('oaatoperator.oaatgroup.OaatType',
+           autospec=True,
+           obj=TestData.kot_mock)
+    def test_podspec_nofreq(self, _):
+        kog = deepcopy(TestData.kog_attrs)
+        kog['spec']['frequency'] = 'nofreq'
+        kog_mock = TestData.new_mock(KubeOaatGroup, kog)
+        with KubeObject(KubeOaatGroup, kog):
+            with self.assertRaises(kopf.PermanentError) as exc:
+                OaatGroup(kopf_object=cast(
+                    CallbackArgs,
+                    TestData.setup_kwargs(kog_mock.obj)))
+            self.assertEqual(
+                str(exc.exception),
+                'invalid frequency specification nofreq in test-kog')
 
 
 class FindJobTests(unittest.TestCase):
@@ -404,57 +421,6 @@ class ValidateTests(unittest.TestCase):
     @patch('oaatoperator.oaatgroup.OaatType',
            autospec=True,
            obj=TestData.kot_mock)
-    def test_verify_is_pod_expected(self, _):
-        with KubeObject(KubeOaatGroup, TestData.kog_attrs):
-            kw = TestData.setup_kwargs(TestData.kog_attrs)
-            kw.setdefault('status', {})['pod'] = 'podname'
-            kw.setdefault('status', {})['currently_running'] = 'itemname'
-            og = OaatGroup(kopf_object=cast(CallbackArgs, kw))
-            self.assertTrue(og.is_pod_expected())
-
-    @patch('oaatoperator.oaatgroup.OaatType',
-           autospec=True,
-           obj=TestData.kot_mock)
-    def test_verify_is_pod_expected_negative(self, _):
-        with KubeObject(KubeOaatGroup, TestData.kog_attrs):
-            kw = TestData.setup_kwargs(TestData.kog_attrs)
-            kw.setdefault('status', {})['pod'] = None
-            kw.setdefault('status', {})['currently_running'] = None
-            og = OaatGroup(kopf_object=cast(CallbackArgs, kw))
-            self.assertFalse(og.is_pod_expected())
-
-    @patch('oaatoperator.oaatgroup.OaatType',
-           autospec=True,
-           obj=TestData.kot_mock)
-    def test_verify_expected_pod(self, _):
-        with KubeObjectPod(TestData.pod_spec) as pod1:
-            with KubeObject(KubeOaatGroup, TestData.kog_attrs):
-                kw = TestData.setup_kwargs(TestData.kog_attrs)
-                kw.setdefault('status', {})['pod'] = pod1.name
-                kw.setdefault('status', {})['currently_running'] = 'itemname'
-                og = OaatGroup(kopf_object=cast(CallbackArgs, kw))
-                self.assertEqual(og.get_status('pod'), pod1.name)
-                with self.assertRaisesRegex(ProcessingComplete,
-                                            'Pod.*exists and is in state'):
-                    og.verify_expected_pod_is_running()
-
-    @patch('oaatoperator.oaatgroup.OaatType',
-           autospec=True,
-           obj=TestData.kot_mock)
-    def test_verify_expected_pod_negative(self, _):
-        with KubeObjectPod(TestData.pod_spec) as pod1:
-            with KubeObject(KubeOaatGroup, TestData.kog_attrs):
-                kw = TestData.setup_kwargs(TestData.kog_attrs)
-                kw.setdefault('status', {})['pod'] = f'not-{pod1.name}'
-                kw.setdefault('status', {})['currently_running'] = 'itemname'
-                og = OaatGroup(kopf_object=cast(CallbackArgs, kw))
-                with self.assertRaisesRegex(ProcessingComplete,
-                                            'item.*failed during validation'):
-                    og.verify_expected_pod_is_running()
-
-    @patch('oaatoperator.oaatgroup.OaatType',
-           autospec=True,
-           obj=TestData.kot_mock)
     def test_delete_rogue_none(self, _):
         with KubeObjectPod(TestData.pod_spec) as pod1:
             with KubeObject(KubeOaatGroup, TestData.kog_attrs):
@@ -462,9 +428,9 @@ class ValidateTests(unittest.TestCase):
                 kw.setdefault('status', {})['pod'] = pod1.name
                 kw.setdefault('status', {})['currently_running'] = 'itemname'
                 og = OaatGroup(kopf_object=cast(CallbackArgs, kw))
+                og.kopf_object.warning = print  # type: ignore
                 self.assertEqual(og.get_status('pod'), pod1.name)
-                # no rogue pod, falls through to
-                # verify_expected_pod_is_running()
+                # no rogue pod
                 with self.assertRaisesRegex(
                         ProcessingComplete,
                         'Pod .* exists and is in state Running'):
@@ -482,8 +448,7 @@ class ValidateTests(unittest.TestCase):
                     kw.setdefault('status',
                                   {})['currently_running'] = 'itemname'
                     og = OaatGroup(kopf_object=cast(CallbackArgs, kw))
-                    # no rogue pod, falls through to
-                    # verify_expected_pod_is_running()
+                    # no rogue pod
                     with self.assertRaisesRegex(
                             ProcessingComplete,
                             'Pod .* exists and is in state Running'):
@@ -501,8 +466,7 @@ class ValidateTests(unittest.TestCase):
                     kw.setdefault('status',
                                   {})['currently_running'] = 'itemname'
                     og = OaatGroup(kopf_object=cast(CallbackArgs, kw))
-                    # no rogue pod, falls through to
-                    # verify_expected_pod_is_running()
+                    # no rogue pod
                     with self.assertRaisesRegex(
                             ProcessingComplete,
                             'Pod .* exists and is in state Running'):
@@ -538,47 +502,6 @@ class ValidateTests(unittest.TestCase):
     @patch('oaatoperator.oaatgroup.OaatType',
            autospec=True,
            obj=TestData.kot_mock)
-    def test_verify_running_pod_nocr(self, _):
-        with KubeObject(KubeOaatGroup, TestData.kog_attrs):
-            kw = TestData.setup_kwargs(TestData.kog_attrs)
-            og = OaatGroup(kopf_object=cast(CallbackArgs, kw))
-            kw.setdefault('status', {})['pod'] = 'podname'
-            kw.setdefault('status', {})['currently_running'] = None
-            with self.assertRaisesRegex(ProcessingComplete, 'internal error'):
-                og.verify_running()
-
-    @patch('oaatoperator.oaatgroup.OaatType',
-           autospec=True,
-           obj=TestData.kot_mock)
-    def test_verify_running_nopod_cr(self, _):
-        with KubeObject(KubeOaatGroup, TestData.kog_attrs):
-            kw = TestData.setup_kwargs(TestData.kog_attrs)
-            og = OaatGroup(kopf_object=cast(CallbackArgs, kw))
-            kw.setdefault('status', {})['pod'] = None
-            kw.setdefault('status', {})['currently_running'] = 'itemname'
-            with self.assertRaisesRegex(ProcessingComplete, 'internal error'):
-                og.verify_running()
-
-    @patch('oaatoperator.oaatgroup.OaatType',
-           autospec=True,
-           obj=TestData.kot_mock)
-    def test_verify_running_expected_running_but_is_not(self, _):
-        with KubeObject(KubeOaatGroup, TestData.kog_attrs):
-            kw = TestData.setup_kwargs(TestData.kog_attrs)
-            og = OaatGroup(kopf_object=cast(CallbackArgs, kw))
-            og.kopf_object.info = print  # type: ignore
-            og.kopf_object.warning = print  # type: ignore
-            og.kopf_object.error = print  # type: ignore
-            kw.setdefault('status', {})['pod'] = 'podname'
-            kw.setdefault('status', {})['currently_running'] = 'itemname'
-            with self.assertRaisesRegex(
-                    ProcessingComplete,
-                    'item itemname failed during validation'):
-                og.verify_running()
-
-    @patch('oaatoperator.oaatgroup.OaatType',
-           autospec=True,
-           obj=TestData.kot_mock)
     def test_verify_running_expected_running_and_is(self, _):
         with KubeObjectPod(TestData.pod_spec) as pod1:
             with KubeObject(KubeOaatGroup, TestData.kog_attrs):
@@ -608,7 +531,7 @@ class OaatGroupTests(unittest.TestCase):
         return super().tearDown()
 
     def test_create_none(self):
-        with self.assertRaisesRegex(InternalError,
+        with self.assertRaisesRegex(kopf.PermanentError,
                                     'OaatGroup must be called with either.*'):
             OaatGroup()
 
@@ -619,44 +542,49 @@ class OaatGroupTests(unittest.TestCase):
         with KubeObject(KubeOaatGroup, TestData.kog_attrs):
             og = OaatGroup(kube_object_name='test-kog', logger=MagicMock())
             with self.assertRaisesRegex(
-                    InternalError,
+                    kopf.PermanentError,
                     'attempt to retrieve find_job_to_run outside of kopf'):
                 og.find_job_to_run()
             with self.assertRaisesRegex(
-                    InternalError,
+                    kopf.PermanentError,
                     'attempt to retrieve validate_items outside of kopf'):
                 og.validate_items()
             with self.assertRaisesRegex(
-                    InternalError,
+                    kopf.PermanentError,
+                    'attempt to retrieve identify_running_pod '
+                    'outside of kopf'):
+                og.identify_running_pod()
+            with self.assertRaisesRegex(
+                    kopf.PermanentError,
+                    'attempt to retrieve verify_running_pod outside of kopf'):
+                og.verify_running_pod()
+            with self.assertRaisesRegex(
+                    kopf.PermanentError,
                     'attempt to retrieve verify_running outside of kopf'):
                 og.verify_running()
             with self.assertRaisesRegex(
-                    InternalError,
-                    'attempt to retrieve verify_state outside of kopf'):
-                og.verify_state('item')
-            with self.assertRaisesRegex(
-                    InternalError,
-                    'attempt to retrieve delete_rogue_pods outside of kopf'):
-                og.delete_rogue_pods('item')
-            with self.assertRaisesRegex(
-                    InternalError,
-                    'attempt to retrieve verify_expected_pod_is_running '
+                    kopf.PermanentError,
+                    'attempt to retrieve delete_non_survivor_pods '
                     'outside of kopf'):
-                og.verify_expected_pod_is_running('item')
+                og.delete_non_survivor_pods('item')
             with self.assertRaisesRegex(
-                    InternalError,
-                    'attempt to retrieve is_pod_expected outside of kopf'):
-                og.is_pod_expected('item')
+                    kopf.PermanentError,
+                    'attempt to retrieve resume_running_pod outside of kopf'):
+                og.resume_running_pod([])
             with self.assertRaisesRegex(
-                    InternalError,
+                    kopf.PermanentError,
+                    'attempt to retrieve select_survivor outside of kopf'):
+                og.select_survivor([])
+            with self.assertRaisesRegex(
+                    kopf.PermanentError,
                     'attempt to retrieve set_status outside of kopf'):
                 og.set_status('state', 'value')
             with self.assertRaisesRegex(
-                    InternalError,
+                    kopf.PermanentError,
                     'attempt to retrieve set_object_status outside of kopf'):
                 og.set_object_status('state', 'value')
             with self.assertRaisesRegex(
-                    InternalError,
+                    kopf.PermanentError,
                     'attempt to retrieve get_kubeobj outside of kopf'):
                 og.get_kubeobj('state', 'value')
 
@@ -678,7 +606,7 @@ class OaatGroupTests(unittest.TestCase):
     def test_create_with_kubeobj_no_logger(self, _):
         with KubeObject(KubeOaatGroup, TestData.kog_attrs):
             with self.assertRaisesRegex(
-                    InternalError,
+                    kopf.PermanentError,
                     'must supply logger= parameter .*kube_object_name'):
                 OaatGroup(kube_object_name='test-kog')
 
@@ -827,7 +755,6 @@ class OaatGroupTests(unittest.TestCase):
 # - validate_items()
 #   X no items
 #   X set annotations
-# - verify_state()
 #   X invalid state (failed pod creation)
 #   X valid states
 # - verify_running_pod()

--- a/tests/test_oaatgroup.py
+++ b/tests/test_oaatgroup.py
@@ -540,7 +540,9 @@ class OaatGroupTests(unittest.TestCase):
            obj=TestData.kot_mock)
     def test_no_kopf(self, _):
         with KubeObject(KubeOaatGroup, TestData.kog_attrs):
-            og = OaatGroup(kube_object_name='test-kog', memo=MagicMock(), logger=MagicMock())
+            og = OaatGroup(kube_object_name='test-kog',
+                           memo=MagicMock(),
+                           logger=MagicMock())
             with self.assertRaisesRegex(
                     kopf.PermanentError,
                     'attempt to retrieve find_job_to_run outside of kopf'):
@@ -593,7 +595,9 @@ class OaatGroupTests(unittest.TestCase):
            obj=TestData.kot_mock)
     def test_create_with_kubeobj(self, _):
         with KubeObject(KubeOaatGroup, TestData.kog_attrs):
-            og = OaatGroup(kube_object_name='test-kog', memo=MagicMock(), logger=MagicMock())
+            og = OaatGroup(kube_object_name='test-kog',
+                           memo=MagicMock(),
+                           logger=MagicMock())
             self.assertIsInstance(og.kube_object, KubeOaatGroup)
             self.assertEqual(og.kopf_object, None)
             self.assertEqual(og.kube_object.name,

--- a/tests/test_oaatitem.py
+++ b/tests/test_oaatitem.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import kopf
 import pykube
 from copy import deepcopy
 
@@ -120,7 +121,8 @@ class TestOaatItems(ExtendedTestCase):
     @patch('oaatoperator.oaatgroup.OaatGroup', autospec=True)
     def test_nondict(self, og_mock):
         with self.assertRaisesRegex(
-                TypeError, 'obj should be dict, not <class \'str\'>=string'):
+                kopf.PermanentError,
+                'obj should be dict, not <class \'str\'>=string'):
             OaatItems(og_mock, 'string')  # type: ignore
 
     @patch('oaatoperator.oaatgroup.OaatGroup', autospec=True)

--- a/tests/test_pod.py
+++ b/tests/test_pod.py
@@ -171,6 +171,6 @@ class StatusTests(unittest.TestCase):
         self.assertIsInstance(p, PodOverseer)
         with self.assertRaisesRegex(
                 ProcessingComplete, f'updating phase for pod {op["name"]}: '
-                f'{op["status"]["phase"]}'):
+                f'new phase={op["status"]["phase"]}'):
             p.update_phase()
         print(og_mock.call_args_list)

--- a/tests/test_pod.py
+++ b/tests/test_pod.py
@@ -2,6 +2,7 @@ import sys
 import os
 import datetime
 import copy
+import kopf
 from pykube import Pod
 
 import unittest
@@ -66,7 +67,7 @@ class BasicTests(unittest.TestCase):
         self.assertIsInstance(op, PodOverseer)
 
     def test_invalid_object(self):
-        with self.assertRaises(ValueError) as exc:
+        with self.assertRaises(kopf.PermanentError) as exc:
             PodOverseer(a=1)  # type: ignore
         self.assertRegex(str(exc.exception),
                          'Overseer must be called with full kopf kwargs.*')

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -154,6 +154,15 @@ class TimeWindowTests(unittest.TestCase):
 
 
 class ParseDurationTests(unittest.TestCase):
+    def test_failures(self):
+        self.assertIsNone(parse_duration(None))  # type: ignore
+        self.assertIsNone(parse_duration(''))
+        self.assertIsNone(parse_duration('0l'))
+        self.assertIsNone(parse_duration('none'))
+        self.assertIsNone(parse_duration('s'))
+        self.assertIsNone(parse_duration('d'))
+        self.assertIsNone(parse_duration('m'))
+
     def test_seconds_only(self):
         self.assertFalse(parse_duration('0s'))
         self.assertEqual(parse_duration('1s'), td(seconds=1))

--- a/tests/testdata.py
+++ b/tests/testdata.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 import oaatoperator.utility
 import logging
 import pykube
+import kopf
 
 from unittest.mock import MagicMock, Mock
 
@@ -58,7 +59,7 @@ class TestData:
             'annotations': body.get('metadata', {}).get('annotations', {}),
             'logger': MagicMock(spec=logging.Logger),
             'patch': {},
-            'memo': {},
+            'memo': kopf.Memo(),
             'event': {},
             'reason': '',
             'old': {},


### PR DESCRIPTION
Move to using the kopf 'memo' instead of writing to status fields, which has proved unreliable.

Also cleaned up some messages and error handling. Now uses kopf.PermanentError and kopf.TemporaryError exceptions to better drive kopf's retry behaviour.