### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/actions-updater.yml
+++ b/.github/workflows/actions-updater.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.3.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.workflow }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,11 +35,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3.1.0
+      uses: actions/checkout@v3.3.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@codeql-bundle-20230217
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -50,7 +50,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@codeql-bundle-20230217
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -64,4 +64,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@codeql-bundle-20230217

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,9 +15,9 @@ jobs:
         k8s-version: [v1.23, v1.24]
     steps:
     - name: Check out code
-      uses: actions/checkout@v3.1.0
+      uses: actions/checkout@v3.3.0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4.3.0
+      uses: actions/setup-python@v4.5.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -57,7 +57,7 @@ jobs:
     needs: test
     steps:
     - name: Check out code
-      uses: actions/checkout@v3.1.0
+      uses: actions/checkout@v3.3.0
     - name: Validate Version
       run: |
         VER=$(grep oaat-operator version.txt | sed -e 's/.*=//' -e 's/\s//g')
@@ -69,9 +69,9 @@ jobs:
     if: ${{ github.event_name == 'push' }}
     steps:
     - name: Check out code
-      uses: actions/checkout@v3.1.0
+      uses: actions/checkout@v3.3.0
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2.2.1
+      uses: docker/setup-buildx-action@v2.4.1
       with:
         buildkitd-flags: --debug
     - name: Login to Repo
@@ -102,7 +102,7 @@ jobs:
         echo "__gitsha__ = '${GITHUB_SHA::7}'" >> oaatoperator/__init__.py
         echo "__build_date__ = '$(date +%Y%m%d%H%M%S)'" >> oaatoperator/__init__.py
     - name: Build the Docker image (with :<sha> and :dev tags)
-      uses: docker/build-push-action@v3.2.0
+      uses: docker/build-push-action@v4.0.0
       with:
         context: .
         file: build/Dockerfile

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,4 +1,4 @@
-kopf==1.35.6
+kopf==1.36.0
 pykube-ng==22.9.0
 PyYAML==6.0
 mypy_extensions

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,9 +1,9 @@
 -r common.txt
-coverage==6.5.0
+coverage==7.2.1
 flake8==6.0.0
 pycodestyle==2.10.0
-pyflakes==3.0.0
-pytest==7.2.0
+pyflakes==3.0.1
+pytest==7.2.1
 pytest-cov==4.0.0
 pytest-mock==3.10.0
 yapf==0.32.0


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v4.0.0](https://github.com/docker/build-push-action/releases/tag/v4.0.0)** on 2023-01-30T18:26:38Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v4.5.0](https://github.com/actions/setup-python/releases/tag/v4.5.0)** on 2023-01-12T11:29:27Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v2.4.1](https://github.com/docker/setup-buildx-action/releases/tag/v2.4.1)** on 2023-02-06T12:17:14Z
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[codeql-bundle-20230217](https://github.com/github/codeql-action/releases/tag/codeql-bundle-20230217)** on 2023-02-17T15:44:00Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.3.0](https://github.com/actions/checkout/releases/tag/v3.3.0)** on 2023-01-05T13:21:21Z
