### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@codeql-bundle-20230217
+      uses: github/codeql-action/init@codeql-bundle-20230304
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -50,7 +50,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@codeql-bundle-20230217
+      uses: github/codeql-action/autobuild@codeql-bundle-20230304
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -64,4 +64,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@codeql-bundle-20230217
+      uses: github/codeql-action/analyze@codeql-bundle-20230304

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v3.3.0
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2.4.1
+      uses: docker/setup-buildx-action@v2.5.0
       with:
         buildkitd-flags: --debug
     - name: Login to Repo


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[codeql-bundle-20230304](https://github.com/github/codeql-action/releases/tag/codeql-bundle-20230304)** on 2023-03-05T04:27:05Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v2.5.0](https://github.com/docker/setup-buildx-action/releases/tag/v2.5.0)** on 2023-03-10T09:47:20Z
