### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/actions-updater.yml
+++ b/.github/workflows/actions-updater.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.workflow }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.7.3
+        uses: saadmk11/github-actions-version-updater@v0.7.4
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.workflow }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,11 +35,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.0
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@codeql-bundle-20230317
         # Override language selection by uncommenting this and choosing your languages
         # with:
         #   languages: go, javascript, csharp, python, cpp, java, ruby
@@ -47,7 +47,7 @@ jobs:
       # Autobuild attempts to build any compiled languages (C/C++, C#, Go, or Java).
       # If this step fails, then you should remove it and run the build manually (see below).
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@codeql-bundle-20230317
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -61,4 +61,4 @@ jobs:
       #     make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@codeql-bundle-20230317

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,7 @@ jobs:
         k8s-version: [v1.23, v1.24]
     steps:
     - name: Check out code
-      uses: actions/checkout@v3.3.0
+      uses: actions/checkout@v3.5.0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4.5.0
       with:
@@ -58,7 +58,7 @@ jobs:
     needs: test
     steps:
     - name: Check out code
-      uses: actions/checkout@v3.3.0
+      uses: actions/checkout@v3.5.0
     - name: Validate Version
       run: |
         VER=$(grep oaat-operator version.txt | sed -e 's/.*=//' -e 's/\s//g')
@@ -72,7 +72,7 @@ jobs:
     if: ${{ github.event_name == 'push' }}
     steps:
     - name: Check out code
-      uses: actions/checkout@v3.3.0
+      uses: actions/checkout@v3.5.0
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2.5.0
       with:


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.5.0](https://github.com/actions/checkout/releases/tag/v3.5.0)** on 2023-03-24T05:41:31Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.7.4](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.7.4)** on 2023-03-15T16:41:04Z
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[codeql-bundle-20230317](https://github.com/github/codeql-action/releases/tag/codeql-bundle-20230317)** on 2023-03-17T13:39:55Z
