### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/actions-updater.yml
+++ b/.github/workflows/actions-updater.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.5.0
+      - uses: actions/checkout@v3.5.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.workflow }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3.5.0
+        uses: actions/checkout@v3.5.2
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,7 @@ jobs:
         k8s-version: [v1.23, v1.24]
     steps:
     - name: Check out code
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v3.5.2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4.5.0
       with:
@@ -48,7 +48,7 @@ jobs:
       run: |
         python3 -m pytest --cov=oaatoperator --cov-append --cov-report=term --cov-report=xml:cov.xml .
     - name: Upload Coverage
-      uses: codecov/codecov-action@v3.1.1
+      uses: codecov/codecov-action@v3.1.2
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
@@ -58,7 +58,7 @@ jobs:
     needs: test
     steps:
     - name: Check out code
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v3.5.2
     - name: Validate Version
       run: |
         VER=$(grep oaat-operator version.txt | sed -e 's/.*=//' -e 's/\s//g')
@@ -72,7 +72,7 @@ jobs:
     if: ${{ github.event_name == 'push' }}
     steps:
     - name: Check out code
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v3.5.2
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2.5.0
       with:


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v3.1.2](https://github.com/codecov/codecov-action/releases/tag/v3.1.2)** on 2023-04-11T20:10:46Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.5.2](https://github.com/actions/checkout/releases/tag/v3.5.2)** on 2023-04-13T12:49:40Z
