### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/actions-updater.yml
+++ b/.github/workflows/actions-updater.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.5.0
+      - uses: actions/checkout@v3.5.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.workflow }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,11 +35,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3.5.0
+        uses: actions/checkout@v3.5.2
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@codeql-bundle-20230403
+        uses: github/codeql-action/init@codeql-bundle-20230418
         # Override language selection by uncommenting this and choosing your languages
         # with:
         #   languages: go, javascript, csharp, python, cpp, java, ruby
@@ -47,7 +47,7 @@ jobs:
       # Autobuild attempts to build any compiled languages (C/C++, C#, Go, or Java).
       # If this step fails, then you should remove it and run the build manually (see below).
       - name: Autobuild
-        uses: github/codeql-action/autobuild@codeql-bundle-20230403
+        uses: github/codeql-action/autobuild@codeql-bundle-20230418
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -61,4 +61,4 @@ jobs:
       #     make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@codeql-bundle-20230403
+        uses: github/codeql-action/analyze@codeql-bundle-20230418

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,9 +15,9 @@ jobs:
         k8s-version: [v1.23, v1.24]
     steps:
     - name: Check out code
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v3.5.2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4.5.0
+      uses: actions/setup-python@v4.6.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -48,7 +48,7 @@ jobs:
       run: |
         python3 -m pytest --cov=oaatoperator --cov-append --cov-report=term --cov-report=xml:cov.xml .
     - name: Upload Coverage
-      uses: codecov/codecov-action@v3.1.1
+      uses: codecov/codecov-action@v3.1.3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: true
@@ -58,7 +58,7 @@ jobs:
     needs: test
     steps:
     - name: Check out code
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v3.5.2
     - name: Validate Version
       run: |
         VER=$(grep oaat-operator version.txt | sed -e 's/.*=//' -e 's/\s//g')
@@ -72,7 +72,7 @@ jobs:
     if: ${{ github.event_name == 'push' }}
     steps:
     - name: Check out code
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v3.5.2
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2.5.0
       with:


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v3.1.3](https://github.com/codecov/codecov-action/releases/tag/v3.1.3)** on 2023-04-20T17:41:43Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.5.2](https://github.com/actions/checkout/releases/tag/v3.5.2)** on 2023-04-13T12:49:40Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v4.6.0](https://github.com/actions/setup-python/releases/tag/v4.6.0)** on 2023-04-20T12:36:13Z
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[codeql-bundle-20230418](https://github.com/github/codeql-action/releases/tag/codeql-bundle-20230418)** on 2023-04-18T17:42:03Z
